### PR TITLE
feat(android): Add firebase-analytics related docs

### DIFF
--- a/docs/android-studio/advanced-setup.md
+++ b/docs/android-studio/advanced-setup.md
@@ -109,6 +109,11 @@ dependencies {
 
 ### اضافه‌کردن لایبرری‌های Firebase
 
+### Firebase-Messaging
+
+> **نکته**:    
+> نسخه‌ی فعلی با نسخه‌های بالای `20.1.1` به بالای `Firebase-Messaging` سازگار نیست و برای استفاده باید حداکثر نسخه‌ی `20.1.0` استفاده شود.
+
 در صورتی که کتابخانه‌ای از فایربیس استفاده می‌کند که خود از `Firebase-messaging` استفاده می‌کند و یا خود از این لایبرری استفاده می‌کنید، ممکن است به دلیل اختلاف نسخه‌ی لایبرری‌ها در هنگام سینک خطا رخ دهد. برای حل این مشکل `firebase-messaging` و `firebase-iid` را اضافه کرده و نسخه‌ی آنها را مطابق دیگر لایبرری‌های فایربیس خود قرار دهید:
 
 ```js
@@ -117,10 +122,22 @@ dependencies {
     // ...
     
     // Add firebase-messaging and firebase-iid with the desired version
+    var fcm_version = '20.1.0'
+    var iid_version = '20.0.2'
     implementation "com.google.firebase:firebase-messaging:$fcm_version"
     implementation "com.google.firebase:firebase-iid:$iid_version"
 }
 ```
+### Firebase-Analytics
+
+در صورتی که لایبرری `Firebase-Analytics` را استفاده می‌کنید بایستی نسخه‌ی `Firebase-Messaging` هماهنگ با نسخه‌ی `Analytics` را نیز اضافه کنید تا خطای `ClassNotFoundException` رخ ندهد.
+
+```js
+var fcm_version = '20.1.0'
+implementation "com.google.firebase:firebase-messaging:$fcm_version"
+implementation "com.google.firebase:firebase-analytics:$analytics_version"
+```
+
 
 در این حالت این دو لایبرری مطابق بقیه بروز خواهند شد.
 


### PR DESCRIPTION
## Changes

- Firebase-Analytics causes crash since it needs a higher Fcm and fails (Still looking for the reason of this issue). Thus, we added a notice in documentation to avoid this problem.

**Note**: Issue will be fixed with the migration to androidX artifact.